### PR TITLE
Update the latest bytefmt import path

### DIFF
--- a/core_service.go
+++ b/core_service.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/pivotal-golang/bytefmt"
+	"code.cloudfoundry.org/bytefmt"
 )
 
 type CoreService struct {


### PR DESCRIPTION
This repository should be imported as code.cloudfoundry.org/bytefmt